### PR TITLE
fetch files and inject them

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -100,6 +100,7 @@ The rest:
 - `collect-all("Figure" 1 "." 3)` collects all the fields into a string. Useful for computing a link target because `target-context(...)` only allows 2 arguments
 - `if(1, true-condition, false-condition)` allows you to conditionally return something. An example would be to combine this with `is-even(...)` to remove all even answers from the back of the Book
 - `is-even(123)` returns `0` if the number is odd, and `111111` otherwise (truthy)
+- `fetch-url('./icon.svg')` injects the contents of the file into the element
 - `x-tag-name()` find out current elements' tag name (ie 'div', 'pre', 'h1')
 - `x-throw()` throws an error (useful for unit tests)
 

--- a/src/browser/functions.js
+++ b/src/browser/functions.js
@@ -119,6 +119,12 @@ FUNCTIONS.push(new FunctionEvaluator('attr', (evaluator, astNode, $contextEl) =>
   }
   return ret
 }))
+FUNCTIONS.push(new FunctionEvaluator('fetch-url', (evaluator, astNode, $contextEl, $) => {
+  const url = evaluator.evaluateFirst()
+  const fetchNode = $(`<transcludeduringserialization url="${url}"/>`)
+  fetchNode[0].__cssLocation = astNode
+  return fetchNode
+}))
 let idCounter = 0
 FUNCTIONS.push(new FunctionEvaluator('x-attr-ensure-id', (evaluator, astNode, $contextEl) => {
   const attrName = 'id'

--- a/src/browser/main.js
+++ b/src/browser/main.js
@@ -136,8 +136,8 @@ module.exports = class Converter {
     }
   }
 
-  serialize (vanillaRules) {
+  serialize (vanillaRules, transcludedFilesMap) {
     vanillaRules = csstree.fromPlainObject(vanillaRules)
-    return serializer(this._engine, this._htmlSourceLookup, this._htmlSourcePath, this._sourceMapPath, vanillaRules, this._htmlOutputPath, this._isXml)
+    return serializer(this._engine, this._htmlSourceLookup, this._htmlSourcePath, this._sourceMapPath, vanillaRules, this._htmlOutputPath, this._isXml, transcludedFilesMap)
   }
 }

--- a/test/unit/svg.in.xhtml
+++ b/test/unit/svg.in.xhtml
@@ -1,0 +1,12 @@
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <head>
+    <style type="text/css-plus+css">
+      body {
+        content: fetch-url('./vanilla.svg');
+      }
+    </style>
+  </head>
+<body>
+
+</body>
+</html>

--- a/test/unit/svg.out.xhtml
+++ b/test/unit/svg.out.xhtml
@@ -1,0 +1,14 @@
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <head>
+    
+  </head>
+<body><!-- DEBUG: Transcluding file './vanilla.svg' -->
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1">
+  <rect x="25" y="25" width="200" height="200" fill="lime" stroke-width="4" stroke="pink" />
+  <circle cx="125" cy="125" r="75" fill="orange" />
+  <polyline points="50,150 50,200 200,200 200,100" stroke="red" stroke-width="4" fill="none" />
+  <line x1="50" y1="50" x2="200" y2="200" stroke="blue" stroke-width="4" />
+</svg>
+</body>
+</html>
+<!-- //# sourceMappingURL=svg.out.xhtml.map -->


### PR DESCRIPTION
like SVG icon files. They are injected so that they can be colored via CSS.

# Example CSS

```css
body { content: fetch-url('./icon.svg'); }
```

Output when run on an empty HTML file:

```html
<html>
  <body><!-- DEBUG: Transcluded file './icon.svg' -->
    <svg xmlns="http://www.w3.org/2000/svg" version="1.1">
      <rect x="25" y="25" width="200" height="200" fill="lime" stroke-width="4" stroke="pink" />
    </svg>
  </body>
</html>
```


Refs https://github.com/Connexions/cnx-easybake/pull/41


Some things to note:

- having a comment or something might be helpful in debugging where this file came from
- there is cruft `<?xml ....` that needs to be stripped out
- We might need to validate that we transcluded XML
- sourcemaps should probably mark the entire SVG file when it it transcluded